### PR TITLE
Fix group spawn not checking target units properly

### DIFF
--- a/fnc/spawn/fn_spawnPlayer.sqf
+++ b/fnc/spawn/fn_spawnPlayer.sqf
@@ -26,7 +26,7 @@ switch(RSTF_SPAWN_TYPE) do {
 		_grp = RSTF_DEATH_GROUP;
 		_index = 0;
 		while { _index < count(_grps) } do {
-			if (alive(leader(_grp))) exitWith {
+			if (leader(_grp) call _usable) exitWith {
 				_spawn = leader(_grp);
 			};
 


### PR DESCRIPTION
The issue here is that the old check wasn't checking if the group leader isn't already used by another player. This isn't an issue in SP but it causes issues in MP where player is not properly spawned since the target is already owned by different player.

Possibly resolves #42