### PR TITLE
Supply drops

### DIFF
--- a/description.ext
+++ b/description.ext
@@ -19,6 +19,7 @@
 #include "dialogs\zui\changelog.hpp"
 #include "dialogs\zui\mainConfig.hpp"
 #include "dialogs\zui\factionSelector.hpp"
+#include "dialogs\zui\supplyDrop.hpp"
 
 #include "modes.hpp"
 #include "options-menu.hpp"

--- a/dialogs/zui/mainConfig.hpp
+++ b/dialogs/zui/mainConfig.hpp
@@ -56,7 +56,7 @@ class MainConfigDialog: ZUI_ColumnLayout
 					class FriendlyFactions : FactionConfig
 					{
 						margin[] = { 0, GUI_SPACING, 0, 0 };
-						class Title: Title { text = "Friendly factions" };
+						class Title: Title { text = "Friendly factions"; };
 						class List: List { class List: List { id = "friendlyList"; }; };
 						class Edit: Edit { id = "friendlyEdit"; };
 					};
@@ -64,7 +64,7 @@ class MainConfigDialog: ZUI_ColumnLayout
 					class EnemyFactions : FactionConfig
 					{
 						margin[] = { 0, GUI_SPACING, 0, 0 };
-						class Title: Title { text = "Enemy factions" };
+						class Title: Title { text = "Enemy factions"; };
 						class List: List { class List: List { id = "enemyList"; }; };
 						class Edit: Edit { id = "enemyEdit"; };
 					};
@@ -73,7 +73,7 @@ class MainConfigDialog: ZUI_ColumnLayout
 					{
 						margin[] = { 0, GUI_SPACING*2, 0, 0 };
 						id = "neutrals";
-						class Title: Title { text = "Neutral factions" };
+						class Title: Title { text = "Neutral factions"; };
 						class List: List {
 							class List: List { id = "neutralList"; };
 							/*class NotUsed: ZUI_TextCenter
@@ -140,7 +140,7 @@ class MainConfigDialog: ZUI_ColumnLayout
 
 				class PickEquipment: ZUI_Button
 				{
-					id = "pickEquipment"
+					id = "pickEquipment";
 					text = "PICK EQUIPMENT";
 					margin[] = { 0, GUI_SPACING, 0, 0 };
 				};

--- a/dialogs/zui/supplyDrop.hpp
+++ b/dialogs/zui/supplyDrop.hpp
@@ -1,0 +1,77 @@
+#define SPACING 0.005
+
+class SupplyDropDialog: ZUI_ColumnLayout
+{
+	margin = 0.2;
+
+	class container: ZUI_ColumnLayout
+	{
+		class titleBar: ZUI_RowLayout
+		{
+			heightType = ZUI_SIZE_ABSOLUTE;
+			height = 0.06;
+			margin[] = { 0, 0, SPACING, 0 };
+
+			class dialogTitle: ZTitle
+			{
+				text = "Supply Drop";
+			};
+		};
+
+		class contentContainer: ZUI_RowLayout
+		{
+			class mapContainer: ZUI_ColumnLayout
+			{
+				class map: ZUI_Control
+				{
+					id = "map";
+					control = "RscMapControl";
+				};
+			};
+
+			class infoContainer: ZUI_ColumnLayout
+			{
+				width = 0.25;
+				margin[] = { 0, 0, 0, SPACING };
+
+				class infoTextContainer: ZUI_ColumnLayout
+				{
+					margin[] = { 0, 0, SPACING, 0 };
+
+					class infoText: ZUI_StructuredText
+					{
+						id = "info";
+						background[] = { 0, 0, 0, 0.7 };
+					};
+				};
+
+				class controlsContainer: ZUI_RowLayout
+				{
+					height = 0.06;
+					heightType = ZUI_SIZE_ABSOLUTE;
+
+					class spacer: ZUI_ColumnLayout
+					{
+						background[] = { 0, 0, 0, 0.7 };
+						margin[] = { 0, SPACING, 0, 0 };
+					};
+					class cancel: ZUI_Button
+					{
+						id = "cancel";
+						width = 0.2;
+						widthType = ZUI_SIZE_ABSOLUTE;
+						margin[] = { 0, SPACING, 0, 0 };
+						text = "CANCEL";
+					};
+					class confirm: ZUI_Button
+					{
+						id = "confirm";
+						width = 0.2;
+						widthType = ZUI_SIZE_ABSOLUTE;
+						text = "CONFIRM";
+					};
+				};
+			};
+		};
+	};
+};

--- a/fnc/functions.hpp
+++ b/fnc/functions.hpp
@@ -165,6 +165,9 @@ class RSTF
 
 		class initArtillerySupport {};
 		class startShelling {};
+		class initSupplyDrop {};
+		class performSupplyDrop {};
+		class rearmInfantry {};
 	};
 
 	class ai

--- a/fnc/support/fn_initSupplyDrop.sqf
+++ b/fnc/support/fn_initSupplyDrop.sqf
@@ -1,0 +1,79 @@
+/*
+	Author:
+	Jan Zípek
+
+	Description:
+	Opens dialog for dropping a suply of something
+
+	Parameters:
+		0: CONFIG CLASS - classname of support config
+	Returns:
+	NOTHING
+*/
+
+// Save the params for later use
+RSTF_SUPPLY_DROP_params = _this;
+
+private _className = param [0, ""];
+
+// Params
+private _cost = getNumber(missionConfigFile >> "RSTF_BUYABLE_SUPPORTS" >> _className >> "cost");
+private _title = getText(missionConfigFile >> "RSTF_BUYABLE_SUPPORTS" >> _className >> "title");
+private _description = getText(missionConfigFile >> "RSTF_BUYABLE_SUPPORTS" >> _className >> "description");
+
+// Spawn the dialog
+RSTF_SUPPLY_DROP_layout = [missionConfigFile >> "SupplyDropDialog"] call ZUI_fnc_createDisplay;
+
+// Create target marker
+RSTF_SUPPLY_DROP_marker = createMarkerLocal ["RSTF_SUPPLY_DROP_marker", getPos(player)];
+RSTF_SUPPLY_DROP_marker setMarkerShape "ICON";
+RSTF_SUPPLY_DROP_marker setMarkerType "hd_objective_noShadow";
+RSTF_SUPPLY_DROP_marker setMarkerColor "ColorBlack";
+
+// Marker should be deleted when display is closed
+([RSTF_SUPPLY_DROP_layout] call ZUI_fnc_display) displayAddEventHandler ["unload", {
+	deleteMarker RSTF_SUPPLY_DROP_marker;
+
+	RSTF_SUPPLY_DROP_layout = [];
+	RSTF_SUPPLY_DROP_params = [];
+	RSTF_SUPPLY_DROP_marker = "";
+}];
+
+// Populate support info
+([RSTF_SUPPLY_DROP_layout, "info"] call ZUI_fnc_getControlById) ctrlSetStructuredText parseText(
+	"<t size='1.2'>" + _title + "</t><br />" +
+	_description
+);
+
+// Move to player
+private _mapCtrl = [RSTF_SUPPLY_DROP_layout, "map"] call ZUI_fnc_getControlById;
+_mapCtrl ctrlMapAnimAdd [0, 0.02, getPos(player)];
+ctrlMapAnimCommit _mapCtrl;
+
+// Move marker around when user selects position
+_mapCtrl ctrlAddEventHandler ["mouseButtonDown", {
+	private _ctrl = _this select 0;
+	private _x = _this select 2;
+	private _y = _this select 3;
+
+	private _pos = _ctrl ctrlMapScreenToWorld [_x, _y];
+
+	RSTF_SUPPLY_DROP_marker setMarkerPos _pos;
+}];
+
+([RSTF_SUPPLY_DROP_layout, "cancel"] call ZUI_fnc_getControlById) ctrlAddEventHandler ["ButtonClick", {
+	[RSTF_SUPPLY_DROP_layout] call ZUI_fnc_closeDisplay;
+}];
+
+([RSTF_SUPPLY_DROP_layout, "confirm"] call ZUI_fnc_getControlById) ctrlAddEventHandler ["ButtonClick", {
+	// Copy currently selected target as last argument
+	RSTF_SUPPLY_DROP_params pushBack getMarkerPos RSTF_SUPPLY_DROP_marker; 
+	// Who is owner
+	RSTF_SUPPLY_DROP_params pushBack player;
+
+	// Drop the stuff!
+	RSTF_SUPPLY_DROP_params remoteExec ["RSTF_fnc_performSupplyDrop", 2];
+
+	// Close dialog
+	[RSTF_SUPPLY_DROP_layout] call ZUI_fnc_closeDisplay;
+}];

--- a/fnc/support/fn_performSupplyDrop.sqf
+++ b/fnc/support/fn_performSupplyDrop.sqf
@@ -1,0 +1,74 @@
+/*
+	Author:
+	Jan Zípek
+
+	Description:
+	Drops supply at specified position.
+
+	Parameters:
+		0: CONFIG CLASS - classname of support config
+		1: POSITION - target position
+		2: OBJECT - player
+
+	Returns:
+	NOTHING
+*/
+
+private _className = param [0];
+private _pos = param [1];
+private _player = param [2];
+
+private _cost = getNumber(missionConfigFile >> "RSTF_BUYABLE_SUPPORTS" >> _className >> "cost");
+private _money = [_player] call RSTF_fnc_getPlayerMoney;
+
+if (_money >= _cost) then {
+	[player, -_cost] call RSTF_fnc_addPlayerMoney;
+
+	private _para = "B_Parachute_02_F";
+	private _smokeShell = "SmokeShellRed";
+
+	private _vehicle = objNull;
+
+	switch (_className) do {
+		case "VehicleAmmo": {
+			_vehicle = "Box_NATO_AmmoVeh_F" createVehicle (getPos player);
+		};
+		case "InfantryAmmo": {
+			_vehicle = "B_supplyCrate_F" createVehicle (getPos player);
+			clearWeaponCargoglobal _vehicle;
+			clearmagazinecargoglobal _vehicle;
+			clearitemcargoglobal _vehicle;
+			clearbackpackcargoglobal _vehicle;
+			private _action = _vehicle addAction [
+				"Rearm",
+				RSTF_fnc_rearmInfantry,
+				[],
+				0,
+				true,
+				true,
+				"",
+				"true",
+				2
+			];
+			_vehicle setUserActionText [
+				_action,
+				"Rearm",
+				"<img size='1.5' image='\a3\ui_f\data\igui\cfg\simpletasks\types\rearm_ca.paa'/>"
+			];
+		};
+		case "ArsenalBox": {
+			_vehicle = "VirtualReammoBox_camonet_F" createVehicle (getPos player);
+			["AmmoboxInit",[_vehicle,true,{true}]] call BIS_fnc_arsenal;
+		};
+	};
+
+	_vehicle setPosATL (_vehicle modelToWorld [5,5,100]);
+
+	private _posAtHeight = _pos vectorAdd [0, 0, 100];
+
+	private _chute = createVehicle [_para, _posAtHeight, [], 0, "NONE"];
+	_vehicle attachTo [_chute, [0, 0, 1]];
+
+	private _smoke = _smokeShell createVehicle position _vehicle;
+	_smoke attachTo [_vehicle,[0,0,0]];
+};

--- a/fnc/support/fn_rearmInfantry.sqf
+++ b/fnc/support/fn_rearmInfantry.sqf
@@ -1,0 +1,20 @@
+params ["_target", "_caller", "_actionId", "_arguments"];
+
+private _primaryWeaponMagazines = primaryWeaponMagazine _caller;
+private _secondaryWeaponMagazines = secondaryWeaponMagazine _caller;
+
+private _callerItems = items _caller;
+
+{
+	if (!(_x in _callerItems)) then {
+		_caller addItem _x;
+	};
+} forEach ["FirstAidKit"];
+
+if (count(_secondaryWeaponMagazines) > 0) then {
+	_caller addMagazines [_secondaryWeaponMagazines#0, 2];
+};
+
+if (count(_primaryWeaponMagazines) > 0) then {
+	_caller addMagazines [_primaryWeaponMagazines#0, 5];
+};

--- a/fnc/ui/fn_showConfig.sqf
+++ b/fnc/ui/fn_showConfig.sqf
@@ -4,10 +4,6 @@ if (isNull(RSTF_CAM)) then {
 	call RSTF_fnc_createCam;
 };
 
-if (true) exitWith {
-	call RSTF_fnc_start;
-};
-
 RSTF_CAM camSetTarget RSTF_CAM_TARGET;
 RSTF_CAM camSetRelPos [3, 3, 2];
 RSTF_CAM camCommit 0;

--- a/fnc/ui/fn_showConfig.sqf
+++ b/fnc/ui/fn_showConfig.sqf
@@ -4,6 +4,10 @@ if (isNull(RSTF_CAM)) then {
 	call RSTF_fnc_createCam;
 };
 
+if (true) exitWith {
+	call RSTF_fnc_start;
+};
+
 RSTF_CAM camSetTarget RSTF_CAM_TARGET;
 RSTF_CAM camSetRelPos [3, 3, 2];
 RSTF_CAM camCommit 0;

--- a/supports.hpp
+++ b/supports.hpp
@@ -53,4 +53,31 @@ class RSTF_BUYABLE_SUPPORTS
 		cost = 2500;
 		execute = "[_this#1, 'R_230mm_Cluster', 10, 60, [1,1.5], [30,40]] call RSTF_fnc_initArtillerySupport";
 	};
+
+	class InfantryAmmo
+	{
+		title = "Infantry ammo drop";
+		description = "Drops infantry ammo crate";
+		picture = "\a3\ui_f\data\igui\cfg\simpletasks\types\rearm_ca.paa";
+		cost = 500;
+		execute = "[_this#1] call RSTF_fnc_initSupplyDrop";
+	};
+
+	class ArsenalBox
+	{
+		title = "Arsenal box";
+		description = "Drops infantry ammo crate";
+		picture = "\a3\ui_f\data\igui\cfg\simpletasks\types\rearm_ca.paa";
+		cost = 1500;
+		execute = "[_this#1] call RSTF_fnc_initSupplyDrop";
+	};
+
+	class VehicleAmmo
+	{
+		title = "Vehicle ammo drop";
+		description = "Drops vehicle ammo crate";
+		picture = "\a3\ui_f\data\igui\cfg\simpletasks\types\rearm_ca.paa";
+		cost = 2000;
+		execute = "[_this#1] call RSTF_fnc_initSupplyDrop";
+	};
 };

--- a/supports.hpp
+++ b/supports.hpp
@@ -57,7 +57,7 @@ class RSTF_BUYABLE_SUPPORTS
 	class InfantryAmmo
 	{
 		title = "Infantry ammo drop";
-		description = "Drops infantry ammo crate";
+		description = "Drops an infantry ammo crate";
 		picture = "\a3\ui_f\data\igui\cfg\simpletasks\types\rearm_ca.paa";
 		cost = 500;
 		execute = "[_this#1] call RSTF_fnc_initSupplyDrop";
@@ -66,7 +66,7 @@ class RSTF_BUYABLE_SUPPORTS
 	class ArsenalBox
 	{
 		title = "Arsenal box";
-		description = "Drops infantry ammo crate";
+		description = "Drops an Arsenal box which allows you to change your equipment";
 		picture = "\a3\ui_f\data\igui\cfg\simpletasks\types\rearm_ca.paa";
 		cost = 1500;
 		execute = "[_this#1] call RSTF_fnc_initSupplyDrop";
@@ -75,7 +75,7 @@ class RSTF_BUYABLE_SUPPORTS
 	class VehicleAmmo
 	{
 		title = "Vehicle ammo drop";
-		description = "Drops vehicle ammo crate";
+		description = "Drops a vehicle ammo crate";
 		picture = "\a3\ui_f\data\igui\cfg\simpletasks\types\rearm_ca.paa";
 		cost = 2000;
 		execute = "[_this#1] call RSTF_fnc_initSupplyDrop";


### PR DESCRIPTION
Adds three new supports:
 - Infantry ammo supply drop
 - Arsenal supply drop
 - Vehicle ammo supply drop


![Screenshot 2024-01-17 214849](https://github.com/SkaceKamen/random-infantry-skirmish/assets/2076742/c5f1cfc1-63c7-4673-b32d-533f5e76a1c7)

![Screenshot 2024-01-17 214914](https://github.com/SkaceKamen/random-infantry-skirmish/assets/2076742/4c5a8664-dff1-4ec1-a998-87e676171722)

![20240117214931_1](https://github.com/SkaceKamen/random-infantry-skirmish/assets/2076742/b3f1e9a9-2435-4c7a-9128-b4ffc12eeed1)
![20240117215033_1](https://github.com/SkaceKamen/random-infantry-skirmish/assets/2076742/ed5c8880-4d30-47cc-b36b-7a1588a5c2cf)
