### PR TITLE
Fix some issues with MP

### DIFF
--- a/description.ext
+++ b/description.ext
@@ -58,6 +58,7 @@ briefing = 0;
 respawn = "INSTANT";
 respawnTemplates[] = { "RSTF_Respawn" };
 respawnOnStart = 0;
+respawnDelay = 0;
 
 class CfgRespawnTemplates
 {

--- a/fnc/all/fn_assignPlayer.sqf
+++ b/fnc/all/fn_assignPlayer.sqf
@@ -22,6 +22,11 @@ RSTF_CAM camCommit _speed;
 sleep _speed;
 // waitUntil { camCommitted RSTF_CAM; };
 
+// Safety check - somebody already took this unit in MP - lets select different unit
+if (isPlayer(_unit) && _unit != player) exitWith {
+	RSTF_DEATH_SIDE spawn RSTF_fnc_spawnPlayer;
+};
+
 // Check if target unit is alive, it's possible it died before we got to it
 if (alive(_unit)) then {
 	// Assign custom equipment if set
@@ -121,8 +126,12 @@ if (alive(_unit)) then {
 		};
 	};
 
-	[_unit] call RSTF_MODE_playerAssigned;
+	[_unit] remoteExec ["RSTF_MODE_playerAssigned", 2];
 } else {
 	// Simulate killed handler
-	[_unit, objNull] call RSTF_fnc_playerKilled;
+	if (isMultiplayer) then {
+		RSTF_DEATH_SIDE spawn RSTF_fnc_spawnPlayer;
+	} else {
+		[_unit, objNull] call RSTF_fnc_playerKilled;
+	};
 };

--- a/fnc/all/fn_initVariables.sqf
+++ b/fnc/all/fn_initVariables.sqf
@@ -13,7 +13,7 @@ SIDE_NEUTRAL = 2;
 // Center point
 RSTF_POINT = [];
 RSTF_DIRECTION = 0;
-RSTF_LOCATION = locationNull;
+RSTF_LOCATION = [];
 
 // Building that shouldn't be populated
 RSTF_BANNED_BUILDINGS = [ "Land_Pier_F", "Land_Metal_Shed_F" ];

--- a/fnc/all/fn_initializeMode.sqf
+++ b/fnc/all/fn_initializeMode.sqf
@@ -41,5 +41,3 @@ RSTF_MODE_unitSpawned = [_mode, "unitSpawned", false] call _loadCallback;
 RSTF_MODE_playerAssigned = [_mode, "playerAssigned", false] call _loadCallback;
 RSTF_MODE_overlayLoop = [_mode, "overlayLoop", false] call _loadCallback;
 
-// Initialize gamemode
-0 call RSTF_MODE_init;

--- a/fnc/all/fn_startBattle.sqf
+++ b/fnc/all/fn_startBattle.sqf
@@ -48,6 +48,9 @@ publicVariable "RSTF_BUYABLE_VEHICLES";
 // Initialize selected gamemode
 call RSTF_fnc_initializeMode;
 
+// Start the gamemode
+0 call RSTF_MODE_init;
+
 // Helper markers for spawns
 [RSTF_POINT, RSTF_SPAWNS] call RSTF_fnc_createPointMarkers;
 

--- a/fnc/modes/fn_initGunGameMode.sqf
+++ b/fnc/modes/fn_initGunGameMode.sqf
@@ -66,6 +66,10 @@ RSTF_MODE_GUN_GAME_init = {
 	};
 
 	RSTF_MODE_GUN_GAME_WEAPONS_INITIALIZED = true;
+
+	publicVariable "RSTF_MODE_GUN_GAME_WEAPONS";
+	publicVariable "RSTF_MODE_GUN_GAME_WEAPONS_INITIALIZED";
+	publicVariable "RSTF_MODE_GUN_GAME_PROGRESS";
 };
 
 RSTF_MODE_GUN_GAME_getUnitIdent = {
@@ -75,6 +79,7 @@ RSTF_MODE_GUN_GAME_getUnitIdent = {
 	} else {
 		_unit getVariable ["ORIGINAL_NAME", -1];
 	};
+
 	_unitIdent;
 };
 
@@ -87,6 +92,7 @@ RSTF_MODE_GUN_GAME_getProgress = {
 	};
 
 	RSTF_MODE_GUN_GAME_PROGRESS set [_unitIdent, 0];
+	publicVariable "RSTF_MODE_GUN_GAME_PROGRESS";
 
 	0;
 };
@@ -128,6 +134,7 @@ RSTF_MODE_GUN_GAME_clearKills = {
 	private _unitIdent = [_unit] call RSTF_MODE_GUN_GAME_getUnitIdent;
 
 	RSTF_MODE_GUN_GAME_KILLS set [_unitIdent, 0];
+	publicVariable "RSTF_MODE_GUN_GAME_KILLS";
 };
 
 RSTF_MODE_GUN_GAME_addProgress = {
@@ -157,8 +164,10 @@ RSTF_MODE_GUN_GAME_addProgress = {
 	};
 
 	RSTF_MODE_GUN_GAME_PROGRESS set [_unitIdent, _current + _change];
+	publicVariable "RSTF_MODE_GUN_GAME_PROGRESS";
+
 	[_unit] call RSTF_MODE_GUN_GAME_clearKills;
-	[_unit] call RSTF_MODE_GUN_GAME_unitSpawned;
+	[_unit] remoteExec ["RSTF_MODE_GUN_GAME_unitSpawned", owner(_unit)];
 	
 	if (isPlayer(_unit)) then {
 		private _progress = [_unit] call RSTF_MODE_GUN_GAME_getProgress;
@@ -179,6 +188,12 @@ RSTF_MODE_GUN_GAME_addProgress = {
 
 RSTF_MODE_GUN_GAME_unitSpawned = {
 	private _unit = param [0];
+
+	// We need to execute this local to the target unit
+	if (owner(_unit) != 0 && owner(_unit) != clientOwner) exitWith {
+		_this remoteExec ["RSTF_MODE_GUN_GAME_unitSpawned", owner(_unit)];
+	};
+
 	private _progress = [_unit] call RSTF_MODE_GUN_GAME_getProgress;
 	private _weapon = RSTF_MODE_GUN_GAME_WEAPONS select _progress;
 	private _weaponConfig = configFile >> "cfgWeapons" >> _weapon;
@@ -207,7 +222,7 @@ RSTF_MODE_GUN_GAME_unitSpawned = {
 		} foreach _muzzles;
 	};
 
-	_unit addWeapon _weapon;
+	_unit addWeaponGlobal _weapon;
 	_unit selectWeapon _weapon;
 };
 

--- a/fnc/modes/fn_initGunGameMode.sqf
+++ b/fnc/modes/fn_initGunGameMode.sqf
@@ -70,6 +70,10 @@ RSTF_MODE_GUN_GAME_init = {
 	publicVariable "RSTF_MODE_GUN_GAME_WEAPONS";
 	publicVariable "RSTF_MODE_GUN_GAME_WEAPONS_INITIALIZED";
 	publicVariable "RSTF_MODE_GUN_GAME_PROGRESS";
+	publicVariable "RSTF_DISABLE_GROUP_SPAWNS";
+	publicVariable "RSTF_DISABLE_SPAWN_TRANSPORTS";
+	publicVariable "RSTF_DISABLE_WAVE_GROUP_SPAWNS";
+	publicVariable "RSTF_DISABLE_MONEY";
 };
 
 RSTF_MODE_GUN_GAME_getUnitIdent = {

--- a/fnc/net/fn_clientEvents.sqf
+++ b/fnc/net/fn_clientEvents.sqf
@@ -21,6 +21,9 @@ if (RSTF_SHOW_CONFIG != -1) then {
 "RSTF_STARTED" addPublicVariableEventHandler {
 	if (_this select 1) then {
 		0 spawn RSTF_fnc_onStarted;
+
+		// Initialize game mode info
+		0 spawn RSTF_fnc_initializeMode;
 	};
 };
 

--- a/fnc/net/fn_onPointChanged.sqf
+++ b/fnc/net/fn_onPointChanged.sqf
@@ -7,6 +7,8 @@
 
 closeDialog 0;
 
+if (count(RSTF_POINT) == 0) exitWith {};
+
 if (isNull(RSTF_CAM)) then {
 	call RSTF_fnc_createCam;
 };


### PR DESCRIPTION
 - fix mode specific client-side functions not being initialized properly in MP
 - fix gun mode not working in MP at all (for clients)
 - fix MP issue where if the assigned unit died before the camera reached it, player would be stuck looking at the dead body
 - fix onPointChanged being executed during initialization
 - added attempt to make the MP spawning more reliable and prevent two players being assigned to the same unit, but it's just a bandaid that could work in some cases, proper solution coming up later

This should resolve #132 #133 #134 #135
There's also attempt to prevent #136